### PR TITLE
fix: add jest.config.js for proper test environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\.tsx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+};


### PR DESCRIPTION
This PR adds jest.config.js to fix the failing GitHub Actions tests by:

- Setting jsdom as the test environment to provide browser APIs
- Configuring TypeScript support with ts-jest
- Setting proper module file extensions

This is a hotfix for the 1.0.0 release to ensure tests pass in CI.