### PR TITLE
ci: improve release workflow triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish Package to NPM
 on:
   release:
-    types: [created]
+    types: [created, published]
 
 jobs:
   build:


### PR DESCRIPTION
## Description
Updated GitHub Actions workflow to trigger on both 'created' and 'published' release events. This ensures the workflow runs in both scenarios when creating a new release directly and when publishing a draft release.

## Motivation and Context
Currently, the workflow only triggers on 'created' events, which means it misses releases that are published from draft state. This change ensures we handle both scenarios correctly.

## How Has This Been Tested?
- Verified that the workflow syntax is valid using GitHub Actions documentation
- This change only affects the trigger conditions and doesn't modify the actual workflow steps

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings